### PR TITLE
Fix compilation for Seq.h

### DIFF
--- a/23Map.h
+++ b/23Map.h
@@ -68,7 +68,7 @@ namespace heist {
         };
 
         Map_() {}
-        
+
         static MAP fromList(const heist::list<std::tuple<K,A>>& pairs)
         {
             return foldl<MAP, std::tuple<K,A>>([] (const MAP& m, std::tuple<K, A> ka) {
@@ -190,7 +190,7 @@ namespace heist {
             else
                 return *this;
         }
-    
+
         /*!
          * Monoidal append = set union.
          */
@@ -300,7 +300,7 @@ namespace heist {
     {
         return foldl(f, a, m.begin());
     }
-    
+
     /*!
      * Fold the map's values into a single value using the specified accumulator function.
      */
@@ -351,4 +351,3 @@ namespace heist {
 };
 
 #endif
-

--- a/23Map.h
+++ b/23Map.h
@@ -4,8 +4,9 @@
 #define _23MAP_H_
 
 #include "23Set.h"
-#include <iostream>
 
+#include <ostream>
+#include <mutex>
 
 namespace heist {
     template <class K, class A, class L, class MAP>
@@ -226,13 +227,13 @@ namespace heist {
      * Thread-safe variant of Map.
      */
     template <class K, class A>
-    class Map : public Map_<K, A, PooledLocker, Map<K, A>>
+    class Map : public Map_<K, A, std::mutex, Map<K, A>>
     {
         public:
             Map() {}
-            Map(const Map_<K, A, PooledLocker, Map<K, A>>& other) : Map_<K, A, PooledLocker, Map<K, A>>(other) {}
-            Map(const heist::list<std::pair<K,A>>& pairs) : Map_<K, A, PooledLocker, Map<K, A>>(pairs) {}
-            Map(std::initializer_list<std::pair<K,A>> il) : Map_<K, A, PooledLocker, Map<K, A>>(il) {}
+            Map(const Map_<K, A, std::mutex, Map<K, A>>& other) : Map_<K, A, std::mutex, Map<K, A>>(other) {}
+            Map(const heist::list<std::pair<K,A>>& pairs) : Map_<K, A, std::mutex, Map<K, A>>(pairs) {}
+            Map(std::initializer_list<std::pair<K,A>> il) : Map_<K, A, std::mutex, Map<K, A>>(il) {}
     };
 
     /*!

--- a/23Set.cpp
+++ b/23Set.cpp
@@ -655,4 +655,3 @@ namespace Set23_Impl {
         }
     }
 };
-

--- a/23Set.cpp
+++ b/23Set.cpp
@@ -1,8 +1,6 @@
 // $Id$
 
 #include "23Set.h"
-#include "Exception.h"
-
 
 namespace Set23_Impl {
 
@@ -210,7 +208,7 @@ namespace Set23_Impl {
                             Position(Node(Node2(n2->p, n2->a, pNode)), 0)
                             %= stack.tail().tail()
                         ).unwind();
-                    default: THROW(AssertionException,"Iterator::unwind() impossible");
+                    default: HEIST_THROW(std::invalid_argument,"Iterator::unwind() impossible");
                 }
             }
             else {
@@ -229,7 +227,7 @@ namespace Set23_Impl {
                             Position(Node(Node3(n3.p, n3.a, n3.q, n3.b, pNode)), 0)
                             %= stack.tail().tail()
                         ).unwind();
-                    default: THROW(AssertionException,"Iterator::unwind() impossible");
+                    default: HEIST_THROW(std::invalid_argument,"Iterator::unwind() impossible");
                 }
             }
         }
@@ -430,7 +428,7 @@ namespace Set23_Impl {
                         );
                     }
                 default:
-                    THROW(AssertionException, "bubble impossible");
+                    HEIST_THROW(std::logic_error, "bubble impossible");
             }  // switch
         }
     }

--- a/23Set.h
+++ b/23Set.h
@@ -26,11 +26,9 @@
 #include "FMap.h"
 #include "LightPtr.h"
 #include <heist/list.h>
-#include "Mutex.h"
-#include "PooledLocker.h"
-#include "template_helpers.h"
 
 #include <boost/variant.hpp>
+#include <mutex>
 #include <stdexcept>
 #include <unistd.h>  // for size_t
 
@@ -450,13 +448,13 @@ namespace heist {
      * Thread-safe variant of Set.
      */
     template <class A>
-    class Set : public Set_<A, PooledLocker, Set<A>>
+    class Set : public Set_<A, std::mutex, Set<A>>
     {
         public:
             Set() {}
-            Set(const Set_<A, PooledLocker, Set<A>>& other) : Set_<A, PooledLocker, Set<A>>(other) {}
-            Set(const heist::list<A>& xs) : Set_<A, PooledLocker, Set<A>>(xs) {}
-            Set(std::initializer_list<A> il) : Set_<A, PooledLocker, Set<A>>(il) {}
+            Set(const Set_<A, std::mutex, Set<A>>& other) : Set_<A, std::mutex, Set<A>>(other) {}
+            Set(const heist::list<A>& xs) : Set_<A, std::mutex, Set<A>>(xs) {}
+            Set(std::initializer_list<A> il) : Set_<A, std::mutex, Set<A>>(il) {}
     };
 
     struct NullLocker {

--- a/23Set.h
+++ b/23Set.h
@@ -71,10 +71,10 @@ namespace Set23_Impl {
 
     struct NoOfIndicesVisitor : public boost::static_visitor<int>
     {
-        int operator()(const Leaf1& l1) const {return 1;}
-        int operator()(const Leaf2& l2) const {return 2;}
-        int operator()(const Node2& n2) const {return 3;}
-        int operator()(const Node3& n3) const {return 5;}
+        int operator()(const Leaf1&) const {return 1;}
+        int operator()(const Leaf2&) const {return 2;}
+        int operator()(const Node2&) const {return 3;}
+        int operator()(const Node3&) const {return 5;}
     };
 
     struct Node {

--- a/23Set.h
+++ b/23Set.h
@@ -52,7 +52,7 @@ namespace Set23_Impl {
         }
         Ptr a;
     };
-    
+
     struct Leaf2 {
         private: Leaf2() : a(Ptr::DUMMY), b(Ptr::DUMMY) {} public:
         Leaf2(const Leaf2& other)
@@ -95,7 +95,7 @@ namespace Set23_Impl {
             boost::recursive_wrapper<Node2>,
             boost::recursive_wrapper<Node3>
         > n;
-        
+
         int getNoOfIndices() const
         {
             return boost::apply_visitor(NoOfIndicesVisitor(), n);
@@ -531,7 +531,7 @@ namespace heist {
         }
         return a;
     }
-    
+
     /*!
      * Fold the set's values into a single value using the specified binary operation.
      */
@@ -540,7 +540,7 @@ namespace heist {
     {
         return foldl(f, a, set.begin());
     }
-    
+
     /*!
      * Fold the set's values into a single value using the specified binary operation.
      */
@@ -667,4 +667,3 @@ std::ostream& operator << (std::ostream& os, heist::USet<A> set) {
 }
 
 #endif
-

--- a/23Set.h
+++ b/23Set.h
@@ -23,7 +23,6 @@
 #ifndef _23SET_H_
 #define _23SET_H_
 
-#include "AssertionException.h"
 #include "FMap.h"
 #include "LightPtr.h"
 #include <heist/list.h>
@@ -32,6 +31,7 @@
 #include "template_helpers.h"
 
 #include <boost/variant.hpp>
+#include <stdexcept>
 #include <unistd.h>  // for size_t
 
 namespace Set23_Impl {
@@ -562,7 +562,7 @@ namespace heist {
             return foldl(f, it.get(), it.next());
         }
         else
-            THROW(AssertionException, "can't fold1 an empty set");
+            HEIST_THROW(std::invalid_argument, "can't fold1 an empty set");
     }
 
     /*!
@@ -577,7 +577,7 @@ namespace heist {
             return foldl(f, it.get(), it.next());
         }
         else
-            THROW(AssertionException, "can't fold1 an empty set");
+            HEIST_THROW(std::invalid_argument, "can't fold1 an empty set");
     }
 
     /*!

--- a/LightPtr.cpp
+++ b/LightPtr.cpp
@@ -1,8 +1,8 @@
 // $Id$
 
 #include "LightPtr.h"
-#include "Mutex.h"
-#include <stdio.h>
+
+#include <pthread.h>
 
 namespace heist {
 #if defined(HAVE_PTHREAD_SPIN_LOCK)

--- a/LightPtr.cpp
+++ b/LightPtr.cpp
@@ -94,4 +94,3 @@ DEFINE_LIGHTPTR(LightPtr, pthread_mutex_t* m = get_lightptr_lock(),
 DEFINE_LIGHTPTR(UnsafeLightPtr,,,)
 
 };
-

--- a/heist/list.h
+++ b/heist/list.h
@@ -119,13 +119,13 @@ namespace heist {
             {
                 return (bool)ocons;
             }
-    
+
             /*!
              * Return the head of this list.  Caller must ensure that this list isn't
              * empty before calling, by casting to bool.
              */
             const A& head() const {return ocons->head;}
-    
+
             /*!
              * Return the tail of this list.  Caller must ensure that this list isn't
              * empty before calling, by casting to bool.
@@ -142,7 +142,7 @@ namespace heist {
                 }
                 return !one && !two;
             }
-            
+
             bool operator != (const list<A>& other) const {
                 return !(*this == other);
             }
@@ -376,7 +376,7 @@ namespace heist {
     }
 
     /*!
-     * Filter the defined values and put them into the output list. 
+     * Filter the defined values and put them into the output list.
      */
     template <class A>
     list<A> catOptional(list<boost::optional<A>> xs) {
@@ -418,4 +418,3 @@ namespace heist {
 };
 
 #endif
-

--- a/heist/list.h
+++ b/heist/list.h
@@ -12,10 +12,11 @@
 #include <iostream>
 #include <list>
 #include <initializer_list>
+#include <stdexcept>
 
-#include "AssertionException.h"
 #include <boost/intrusive_ptr.hpp>
 
+#define HEIST_THROW(exc, msg) throw exc(msg)
 
 // ------ New implementation
 
@@ -329,7 +330,7 @@ namespace heist {
         if (xs)
             return foldl(f, xs.head(), xs.tail());
         else
-            THROW(AssertionException, "can't fold1 an empty set");
+            HEIST_THROW(std::invalid_argument, "can't fold1 an empty set");
     }
 
     /*!
@@ -341,7 +342,7 @@ namespace heist {
         if (xs)
             return foldr(f, xs.head(), xs.tail());
         else
-            THROW(AssertionException, "can't fold1 an empty set");
+            HEIST_THROW(std::invalid_argument, "can't fold1 an empty set");
     }
 
     template <class A>

--- a/heist/list.h
+++ b/heist/list.h
@@ -4,6 +4,7 @@
 #define _HEIST_LIST_H_
 
 #include <functional>
+#include <boost/intrusive_ptr.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <boost/shared_ptr.hpp>
@@ -13,8 +14,6 @@
 #include <list>
 #include <initializer_list>
 #include <stdexcept>
-
-#include <boost/intrusive_ptr.hpp>
 
 #define HEIST_THROW(exc, msg) throw exc(msg)
 


### PR DESCRIPTION
Fix compilation for including `Seq.h`. This includes a few changes, most notably:

* Throwing standard exceptions instead of `AssertionException`
* Using `std::mutex` instead of `PooledLocker` (for now)

Please let me know about coding style issues, there's no problem to adapt to whatever conventions you prefer :-)
